### PR TITLE
Add content to linked pages

### DIFF
--- a/css/discover.css
+++ b/css/discover.css
@@ -4,7 +4,8 @@ body {
 }
 div.paragraph {
 	font-weight: 100;
-	font-family: 'Lato', sans-serif;
+  font-family: 'Lato', sans-serif;
+  text-align: left;
 }
 div.transbox {
   margin: 30px;

--- a/css/events.css
+++ b/css/events.css
@@ -22,7 +22,7 @@ div.paragraph {
 
 .paragraph .parabody{
 	font-size: 25px;
-	text-align: justify;
+	text-align: left;
 }
 
 .card {

--- a/css/mentorship.css
+++ b/css/mentorship.css
@@ -7,7 +7,8 @@ body {
 }
 div.paragraph {
 	font-weight: 100;
-	font-family: 'Lato', sans-serif;
+  font-family: 'Lato', sans-serif;
+  text-align:  left;
 }
 div.transbox {
   margin: 30px;

--- a/html/discover.html
+++ b/html/discover.html
@@ -14,8 +14,9 @@
 		<heading>Discover Opportunities</heading>
 		<br>
 		<br>
-		<parabody style="text-align:  left;">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</parabody>
-		<p></p>
+		<p>Would you like to make a difference and see your ideas become a reality? When you join ACM-W you will have the opportunity to work on various projects and make a mark in the computational world.</p>
+		<p>The NITK chapter has many events lined up and will be offering multiple scholarships and competitions to encourage you to set goals, meet new people and make a change in today’s world.</p>
+		<p>Get inspired and empower women.</p>
 	</div>
 	<br>
 	<div class="button button-container" align="middle"><b>Register Now</b></div>

--- a/html/events.html
+++ b/html/events.html
@@ -56,7 +56,7 @@
 	      		<div class="paragraph">
 					<div class="heading">Our Events</div>
 					<div class="parabody">
-						Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. 
+						With our events, we hope to help women to get more exposure and encouragement to pursue their scientific dreams. We are going to put in joint efforts to ensure that women get the support, funds and guidance that they require to explore and achieve their unfulfilled goals. 
 					</div>
 				</div>
     		</div>

--- a/html/mentorship.html
+++ b/html/mentorship.html
@@ -10,12 +10,16 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
 <body class="background container" style="padding: 50px;">
-	<div class="paragraph">
-		<heading>Mentorship System</heading>
-		<br>
-		<br>
-		<parabody style="text-align:  left;">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type <br> and scrambled it to make a type specimen book. It has survived not only five centuries, but <br>		also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in <br> the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more <br> recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</parabody>
-		<p></p>
+	<div class="row">
+		<div class="col-lg-10 col-md-12 col-sm-12">
+			<div class="paragraph">
+				<heading>Mentorship System</heading>
+				<br>
+				<br>			
+				<p>The ACM-W mentorship program will pair juniors with seniors from ACM. We believe that giving students the opportunity to interact with experienced people from their field will encourage them in their journey through college. </p>
+				<p>As part of this mentorship system we will help participants with their academics and career planning. They will also gain research opportunities to explore new fields so that they can eventually choose a track that best matches their skills.</p>
+			</div>
+		</div>
 	</div>
 	<br>
 	<div class="button button-container" align="middle"><b>SIGN UP</b></div>


### PR DESCRIPTION
Changes:

1) Mentorship page:

- Rephrased copy so that it didn’t duplicate content from homepage
- Added copy to page
- Added row div and col’s to prevent copy from overlapping on background image

2) Discover page:

- Rephrased copy so that it didn't duplicate content from homepage.
- Added copy to page
- Changed paragraphs from "parabody" to "p"
- Moved text alignment to div.pararaph on CSS stylesheet

3) Our Events page:

- Added text that was not already visible on homepage to section entitled "Our Events".
- Changed text alignment from "justified" to "left" due to formatting issues after adding genuine copy.

Referencing issue https://github.com/acm-w-nitk/acm-w-nitk.github.io/issues/61